### PR TITLE
Add the frame to pack3d

### DIFF
--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -35,6 +35,7 @@ func main() {
 	    done          func()
 	    totalVolume   float64
 		dimension     []float64
+		ntime         int
 		)
 
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -52,7 +53,7 @@ func main() {
 			continue
 		}
 	}
-	frameSize := fauxgl.V(dimension[0], dimension[1], dimension[2])
+	frameSize := fauxgl.V(dimension[0]/2, dimension[1]/2, dimension[2]/2)
 
 	/* Loading stl models */
 	for _, arg := range os.Args[4:] {
@@ -104,7 +105,11 @@ func main() {
 	/* This loop is to find the best packing stl, thus it will generate mutiple output 
 Add 'break' in the loop to stop program */
 	for {
-		model = model.Pack(annealingIterations, nil, singleStlSize, frameSize)
+		model, ntime = model.Pack(annealingIterations, nil, singleStlSize, frameSize)
+		if ntime >= 9990{
+			model.Reset()
+			continue
+		}
 		score := model.Energy()  // score < 1, the smaller the better
 		if score < best {
 			best = score

--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -106,7 +106,7 @@ func main() {
 Add 'break' in the loop to stop program */
 	for {
 		model, ntime = model.Pack(annealingIterations, nil, singleStlSize, frameSize)
-		if ntime >= 9990{
+		if ntime >= 19990{
 			model.Reset()
 			continue
 		}

--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -8,15 +8,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/fogleman/fauxgl"
+	"github.com/fogleman/fauxgl" //fauxgl is a go library
 	"github.com/fogleman/pack3d/pack3d"
 )
 
 const (
 	bvhDetail           = 8
-	annealingIterations = 2000000
+	annealingIterations = 2000000 // # of trials
 )
 
+
+/* This function returns current time (it's a timer) */ 
 func timed(name string) func() {
 	if len(name) > 0 {
 		fmt.Printf("%s... ", name)
@@ -28,7 +30,11 @@ func timed(name string) func() {
 }
 
 func main() {
+	var stlsize []fauxgl.Vector
+	//var boundsize fauxgl.Vector
 	var done func()
+
+	boundsize := fauxgl.V(50.0, 50.0, 50.0)
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
@@ -36,6 +42,8 @@ func main() {
 	count := 1
 	ok := false
 	var totalVolume float64
+
+	/* Loading stl models */
 	for _, arg := range os.Args[1:] {
 		_count, err := strconv.ParseInt(arg, 0, 0)
 		if err == nil {
@@ -52,6 +60,12 @@ func main() {
 
 		totalVolume += mesh.BoundingBox().Volume()
 		size := mesh.BoundingBox().Size()
+		for i:=0; i<count; i++{
+			stlsize = append(stlsize, size)
+		}
+		//fmt.Println(reflect.TypeOf(stlsize))
+
+		// fmt.Println(" My name is Minglun ")
 		fmt.Printf("  %d triangles\n", len(mesh.Triangles))
 		fmt.Printf("  %g x %g x %g\n", size.X, size.Y, size.Z)
 
@@ -60,6 +74,7 @@ func main() {
 		done()
 
 		done = timed("building bvh tree")
+
 		model.Add(mesh, bvhDetail, count)
 		ok = true
 		done()
@@ -73,17 +88,20 @@ func main() {
 		return
 	}
 
+	//fmt.Println(len(stlsize))
 	side := math.Pow(totalVolume, 1.0/3)
-	model.Deviation = side / 32
+	model.Deviation = side / 32  //change deviation to change distance between models, set a minimum here
 
-	best := 1e9
+	best := 1e9  //the best score
+	/* This loop is to find the best packing stl, thus it will generate mutiple output 
+Add 'break' in the loop to stop program */
 	for {
-		model = model.Pack(annealingIterations, nil)
-		score := model.Energy()
+		model = model.Pack(annealingIterations, nil, stlsize, boundsize)
+		score := model.Energy()  // score < 1, the smaller the better
 		if score < best {
 			best = score
 			done = timed("writing mesh")
-			model.Mesh().SaveSTL(fmt.Sprintf("pack3d-%.3f.stl", score))
+			model.Mesh().SaveSTL(fmt.Sprintf("pack3d-%.3f.stl", score))  // calling the mesh function in model
 			// model.TreeMesh().SaveSTL(fmt.Sprintf("out%dtree.stl", int(score*100000)))
 			done()
 		}

--- a/pack3d/anneal.go
+++ b/pack3d/anneal.go
@@ -18,7 +18,7 @@ type Annealable interface {
 	Copy() Annealable
 }
 
-func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback AnnealCallback, stlsize []fauxgl.Vector, boundsize fauxgl.Vector) Annealable {
+func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback AnnealCallback, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) Annealable {
 	start := time.Now()
 	factor := -math.Log(maxTemp / minTemp)
 	state = state.Copy()
@@ -36,7 +36,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 		if step%rate == 0 {
 			showProgress(step, steps, bestEnergy, time.Since(start).Seconds())
 		}
-		undo := state.DoMove(stlsize, boundsize)
+		undo := state.DoMove(singleStlSize, frameSize)
 		energy := state.Energy()
 		change := energy - previousEnergy
 		if change > 0 && math.Exp(-change/temp) < rand.Float64() {

--- a/pack3d/anneal.go
+++ b/pack3d/anneal.go
@@ -13,12 +13,12 @@ type AnnealCallback func(Annealable)
 
 type Annealable interface {
 	Energy() float64
-	DoMove([]fauxgl.Vector, fauxgl.Vector) Undo
+	DoMove([]fauxgl.Vector, fauxgl.Vector) (Undo, int)
 	UndoMove(Undo)
 	Copy() Annealable
 }
 
-func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback AnnealCallback, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) Annealable {
+func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback AnnealCallback, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) (Annealable, int) {
 	start := time.Now()
 	factor := -math.Log(maxTemp / minTemp)
 	state = state.Copy()
@@ -36,7 +36,10 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 		if step%rate == 0 {
 			showProgress(step, steps, bestEnergy, time.Since(start).Seconds())
 		}
-		undo := state.DoMove(singleStlSize, frameSize)
+		undo, ntime := state.DoMove(singleStlSize, frameSize)
+		if ntime >= 9990{
+			return bestState, ntime
+		}
 		energy := state.Energy()
 		change := energy - previousEnergy
 		if change > 0 && math.Exp(-change/temp) < rand.Float64() {
@@ -54,7 +57,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 	}
 	showProgress(steps, steps, bestEnergy, time.Since(start).Seconds())
 	fmt.Println()
-	return bestState
+	return bestState, 1
 }
 
 /* This function shows progress, not necessary*/

--- a/pack3d/anneal.go
+++ b/pack3d/anneal.go
@@ -37,7 +37,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 			showProgress(step, steps, bestEnergy, time.Since(start).Seconds())
 		}
 		undo, ntime := state.DoMove(singleStlSize, frameSize)
-		if ntime >= 9990{
+		if ntime >= 19990{
 			return bestState, ntime
 		}
 		energy := state.Energy()

--- a/pack3d/model.go
+++ b/pack3d/model.go
@@ -95,9 +95,9 @@ func (m *Model) Reset() {
 	}
 }
 
-func (m *Model) Pack(iterations int, callback AnnealCallback, stlsize []fauxgl.Vector, boundsize fauxgl.Vector) *Model {
+func (m *Model) Pack(iterations int, callback AnnealCallback, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) *Model {
 	e := 0.5
-	return Anneal(m, 1e0*e, 1e-4*e, iterations, callback, stlsize, boundsize).(*Model)
+	return Anneal(m, 1e0*e, 1e-4*e, iterations, callback, singleStlSize, frameSize).(*Model)
 }
 
 func (m *Model) Meshes() []*fauxgl.Mesh {
@@ -159,13 +159,13 @@ func (m *Model) ValidChange(i int) bool {
 	return true
 }
 
-func (m *Model) ValidBound(i int, stlsize []fauxgl.Vector, boundsize fauxgl.Vector) bool {
+func (m *Model) ValidBound(i int, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) bool {
 	var points []fauxgl.Vector
 	var point fauxgl.Vector
 
 	item := m.Items[i]
 	rotation := Rotations[item.Rotation]
-	size := stlsize[i]
+	size := singleStlSize[i]
 
 	points = append(points,fauxgl.V(0.0, 0.0, 0.0))
 	points = append(points,fauxgl.V(size.X, 0.0, 0.0))
@@ -181,7 +181,7 @@ func (m *Model) ValidBound(i int, stlsize []fauxgl.Vector, boundsize fauxgl.Vect
 		point = rotation.MulPosition(point)
 		point = point.Add(item.Translation)
 		point = point.Abs()
-		if point.Max(boundsize) == boundsize{
+		if point.Max(frameSize) == frameSize {
 			//fmt.Println(point)
 			continue
 		} else {
@@ -210,7 +210,7 @@ func (m *Model) Energy() float64 {
 	return m.Volume() / m.MaxVolume
 }
 
-func (m *Model) DoMove(stlsize []fauxgl.Vector, boundsize fauxgl.Vector) Undo {
+func (m *Model) DoMove(singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) Undo {
 	i := rand.Intn(len(m.Items)) // choose a random index in models
 	//fmt.Println(len(m.Items))
 	item := m.Items[i]  // single model
@@ -231,7 +231,7 @@ func (m *Model) DoMove(stlsize []fauxgl.Vector, boundsize fauxgl.Vector) Undo {
 		}
 		//fmt.Println("yes")
 
-		if m.ValidChange(i) && m.ValidBound(i, stlsize, boundsize) {
+		if m.ValidChange(i) && m.ValidBound(i, singleStlSize, frameSize) {
 			break
 		}
 		item.Rotation = undo.Rotation

--- a/pack3d/model.go
+++ b/pack3d/model.go
@@ -4,19 +4,22 @@ import (
 	"math"
 	"math/rand"
 
+
 	"github.com/fogleman/fauxgl"
 )
 
 var Rotations []fauxgl.Matrix
 
-func init() {
-	for i := 0; i < 4; i++ {
-		for s := -1; s <= 1; s += 2 {
-			for a := 1; a <= 3; a++ {
-				up := AxisZ.Vector()
-				m := fauxgl.Rotate(up, float64(i)*fauxgl.Radians(90))
-				m = m.RotateTo(up, Axis(a).Vector().MulScalar(float64(s)))
-				Rotations = append(Rotations, m)
+func init() { // do the for loop 24 times for all the rotation posibility
+	for i := 0; i < 4; i++ { // every axis 4 times to return to the original position
+		for s := -1; s <= 1; s += 2 {  // switch axis direction - or +
+			for a := 1; a <= 3; a++ { // switch axis (3 axis)
+				up := AxisZ.Vector() // z axis
+				//fmt.Println(up)
+				m := fauxgl.Rotate(up, float64(i)*fauxgl.Radians(90)) // Rotation matrix in z axis (4 by 4 matrix)
+				//fmt.Println(Axis(a).Vector().MulScalar(float64(s))) is all axis
+				m = m.RotateTo(up, Axis(a).Vector().MulScalar(float64(s))) //rotation matrix in all axis(4 by 4)
+				Rotations = append(Rotations, m) // 24 rotation matrices
 			}
 		}
 	}
@@ -30,7 +33,7 @@ type Undo struct {
 
 type Item struct {
 	Mesh        *fauxgl.Mesh
-	Trees       []Tree
+	Trees       []Tree // what is Trees?
 	Rotation    int
 	Translation fauxgl.Vector
 }
@@ -77,8 +80,9 @@ func (m *Model) add(mesh *fauxgl.Mesh, trees []Tree) {
 		d *= 1.2
 	}
 	tree := trees[0]
+	//fmt.Println(tree[0].Volume)
 	m.MinVolume = math.Max(m.MinVolume, tree[0].Volume())
-	m.MaxVolume += tree[0].Volume()
+	m.MaxVolume += tree[0].Volume()  // what is tree[0]?
 }
 
 func (m *Model) Reset() {
@@ -91,12 +95,13 @@ func (m *Model) Reset() {
 	}
 }
 
-func (m *Model) Pack(iterations int, callback AnnealCallback) *Model {
+func (m *Model) Pack(iterations int, callback AnnealCallback, stlsize []fauxgl.Vector, boundsize fauxgl.Vector) *Model {
 	e := 0.5
-	return Anneal(m, 1e0*e, 1e-4*e, iterations, callback).(*Model)
+	return Anneal(m, 1e0*e, 1e-4*e, iterations, callback, stlsize, boundsize).(*Model)
 }
 
 func (m *Model) Meshes() []*fauxgl.Mesh {
+	//fmt.Println("yes I will")
 	result := make([]*fauxgl.Mesh, len(m.Items))
 	for i, item := range m.Items {
 		mesh := item.Mesh.Copy()
@@ -136,10 +141,12 @@ func (m *Model) TreeMesh() *fauxgl.Mesh {
 	return result
 }
 
+/* This function is to make sure no intersection between objects*/
 func (m *Model) ValidChange(i int) bool {
 	item1 := m.Items[i]
 	tree1 := item1.Trees[item1.Rotation]
-	for j := 0; j < len(m.Items); j++ {
+	//fmt.Println(item1.Translation)
+	for j := 0; j < len(m.Items); j++ {  // go through all other items
 		if j == i {
 			continue
 		}
@@ -151,6 +158,40 @@ func (m *Model) ValidChange(i int) bool {
 	}
 	return true
 }
+
+func (m *Model) ValidBound(i int, stlsize []fauxgl.Vector, boundsize fauxgl.Vector) bool {
+	var points []fauxgl.Vector
+	var point fauxgl.Vector
+
+	item := m.Items[i]
+	rotation := Rotations[item.Rotation]
+	size := stlsize[i]
+
+	points = append(points,fauxgl.V(0.0, 0.0, 0.0))
+	points = append(points,fauxgl.V(size.X, 0.0, 0.0))
+	points = append(points,fauxgl.V(0.0, size.Y, 0.0))
+	points = append(points,fauxgl.V(0.0, 0.0, size.Z))
+	points = append(points,fauxgl.V(size.X, size.Y, 0.0))
+	points = append(points,fauxgl.V(size.X, 0.0, size.Z))
+	points = append(points,fauxgl.V(0.0, size.Y, size.Z))
+	points = append(points,size)
+
+	for j:=0; j<8; j++{
+		point = points[j]
+		point = rotation.MulPosition(point)
+		point = point.Add(item.Translation)
+		point = point.Abs()
+		if point.Max(boundsize) == boundsize{
+			//fmt.Println(point)
+			continue
+		} else {
+			//fmt.Println(point)
+			return false
+		}
+	}
+	return true
+}
+
 
 func (m *Model) BoundingBox() fauxgl.Box {
 	box := fauxgl.EmptyBox
@@ -169,21 +210,28 @@ func (m *Model) Energy() float64 {
 	return m.Volume() / m.MaxVolume
 }
 
-func (m *Model) DoMove() Undo {
-	i := rand.Intn(len(m.Items))
-	item := m.Items[i]
+func (m *Model) DoMove(stlsize []fauxgl.Vector, boundsize fauxgl.Vector) Undo {
+	i := rand.Intn(len(m.Items)) // choose a random index in models
+	//fmt.Println(len(m.Items))
+	item := m.Items[i]  // single model
 	undo := Undo{i, item.Rotation, item.Translation}
 	for {
 		if rand.Intn(4) == 0 {
-			// rotate
-			item.Rotation = rand.Intn(len(Rotations))
+			// rotate, 1/4 of probability
+			item.Rotation = rand.Intn(len(Rotations)) // do a random rotation, it's a random index
 		} else {
-			// translate
-			offset := Axis(rand.Intn(3) + 1).Vector()
-			offset = offset.MulScalar(rand.NormFloat64() * m.Deviation)
-			item.Translation = item.Translation.Add(offset)
+			// translate, 3/4 of probability
+			offset := Axis(rand.Intn(3) + 1).Vector()  // Pick a random axis
+			offset = offset.MulScalar(rand.NormFloat64() * m.Deviation)  // A random translation in x or y or z (vector)
+			//fmt.Println(item.Translation)
+			item.Translation = item.Translation.Add(offset)  // add offset to translation
+			//fmt.Println(offset)
+			//fmt.Println(item.Translation)
+			//fmt.Println("------")
 		}
-		if m.ValidChange(i) {
+		//fmt.Println("yes")
+
+		if m.ValidChange(i) && m.ValidBound(i, stlsize, boundsize) {
 			break
 		}
 		item.Rotation = undo.Rotation
@@ -205,3 +253,4 @@ func (m *Model) Copy() Annealable {
 	}
 	return &Model{items, m.MinVolume, m.MaxVolume, m.Deviation}
 }
+

--- a/pack3d/model.go
+++ b/pack3d/model.go
@@ -11,8 +11,9 @@ import (
 var Rotations []fauxgl.Matrix
 
 func init() { // do the for loop 24 times for all the rotation posibility
+	axisDirections := [2]int{-1, 1}
 	for i := 0; i < 4; i++ { // every axis 4 times to return to the original position
-		for s := -1; s <= 1; s += 2 {  // switch axis direction - or +
+		for _, s := range axisDirections{  // switch axis direction - or +
 			for a := 1; a <= 3; a++ { // switch axis (3 axis)
 				up := AxisZ.Vector() // z axis
 				//fmt.Println(up)
@@ -161,6 +162,8 @@ func (m *Model) ValidChange(i int) bool {
 	return true
 }
 
+
+/*True if the passed move it within maximum_packing_area, false in all other cases.*/
 func (m *Model) ValidBound(i int, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) bool {
 	var points []fauxgl.Vector
 	var point fauxgl.Vector
@@ -226,7 +229,6 @@ func (m *Model) DoMove(singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) (
 			offset = offset.MulScalar(rand.NormFloat64() * m.Deviation)  // A random translation in x or y or z (vector)
 			item.Translation = item.Translation.Add(offset)  // add offset to translation
 		}
-		//fmt.Println("226")
 
 		if m.ValidChange(i) && m.ValidBound(i, singleStlSize, frameSize) {
 			break


### PR DESCRIPTION
### Description
---

- Modified pack3d/cmd/pack3d/main.go and pack3d/pack3d/model.go.

- Add a frame to the software so that the final packing model will be in the frame.

- Add some notes on the scripts for better understanding.

- The frame now is 100 * 100 * 100, will make it changable later.

- It cannot ensure to output a result, especially for large number, working on this now and try to fix it. 

- To run the software, input `pack3d {frame_size_x,frame_size_y,frame_size_z} number_of_stl filename.stl` . For example ` pack3d {60,80,100} 3 Pika.stl 2 corner.stl`. Attension, no space between coordinate.  

### Ticket(s):
---
- [ch999](https://app.clubhouse.io/authentise/story/999/updated-to-use-new-3d-packing-tool)
