### PR TITLE
Add spacing for pack3d

### DIFF
--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -1,6 +1,9 @@
-/* Instruction: write down this into the command line to use the software
+/*
+Instruction: write down this into the command line to use the software
 <pack3d {your_frame_size_X,your_frame_size_Y,your_frame_size_Z} spacing your_output_name STL_numbers STL_path STL_numbers STL_path .....>
-For example: <pack3d {100,100,100} 5 Pikacu 1 /home/corner.stl 2 /home/Pika.stl>*/
+For example: <pack3d {100,100,100} 5 Pikacu 1 /home/corner.stl 2 /home/Pika.stl>
+The unit of frame and spacing is millimeters.
+*/
 
 package main
 

--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	/*Loading frame size*/
 	for _, j := range os.Args[1:5]{
-		_dimension, err := strconv.ParseInt(j, 0, 0)
+		_dimension, err := strconv.ParseFloat(j, 64)
 		if err == nil{
 			dimension = append(dimension, float64(_dimension))
 			continue

--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -1,6 +1,6 @@
 /* Instruction: write down this into the command line to use the software
-<pack3d {your_frame_size_X,your_frame_size_Y,your_frame_size_Z} your_output_name STL_numbers STL_path STL_numbers STL_path .....>
-For example: <pack3d {100,100,100} Pikacu 1 /home/corner.stl 2 /home/Pika.stl>*/
+<pack3d {your_frame_size_X,your_frame_size_Y,your_frame_size_Z} spacing your_output_name STL_numbers STL_path STL_numbers STL_path .....>
+For example: <pack3d {100,100,100} 5 Pikacu 1 /home/corner.stl 2 /home/Pika.stl>*/
 
 package main
 
@@ -42,14 +42,18 @@ func main() {
 		Transformation   [4][4]float64
 	}
 
+	type err_msg struct {
+		Error            string
+	}
+
 	var (
 		singleStlSize []fauxgl.Vector
 	    done          func()
 	    totalVolume   float64
 		dimension     []float64
 		ntime         int
-		srcStlNames     []string
-		transMaps    []TransMap
+		srcStlNames   []string
+		transMaps     []TransMap
 		)
 
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -58,9 +62,8 @@ func main() {
 	count := 1
 	ok := false
 
-
 	/*Loading frame size*/
-	for _, j := range os.Args[1:4]{
+	for _, j := range os.Args[1:5]{
 		_dimension, err := strconv.ParseInt(j, 0, 0)
 		if err == nil{
 			dimension = append(dimension, float64(_dimension))
@@ -68,9 +71,10 @@ func main() {
 		}
 	}
 	frameSize := fauxgl.V(dimension[0]/2, dimension[1]/2, dimension[2]/2)
+	spacing := dimension[3]/2.0
 
 	/* Loading stl models */
-	for _, arg := range os.Args[5:] {
+	for _, arg := range os.Args[6:] {
 		_count, err := strconv.ParseInt(arg, 0, 0)
 		if err == nil {
 			count = int(_count)
@@ -100,13 +104,13 @@ func main() {
 
 		done = timed("building bvh tree")
 
-		model.Add(mesh, bvhDetail, count)
+		model.Add(mesh, bvhDetail, count, spacing)
 		ok = true
 		done()
 	}
 
 	if !ok {
-		fmt.Println("Usage: pack3d N1 mesh1.stl N2 mesh2.stl ...")
+		fmt.Println("Usage: pack3d frame_size output_fname N1 mesh1.stl N2 mesh2.stl ...")
 		fmt.Println(" - Packs N copies of each mesh into as small of a volume as possible.")
 		fmt.Println(" - Runs forever, looking for the best packing.")
 		fmt.Println(" - Results are written to disk whenever a new best is found.")
@@ -114,7 +118,7 @@ func main() {
 	}
 
 	side := math.Pow(totalVolume, 1.0/3)
-	model.Deviation = side / 32  //change deviation to change distance between models, set a minimum here
+	model.Deviation = side / 32  //it is not the distance between objects. And it seems that it will not reflect the distance.
 
 	best := 1e9  //the best score
 	/* This loop is to find the best packing stl, thus it will generate mutiple output
@@ -132,7 +136,18 @@ Add 'break' in the loop to stop program */
 				model.Reset()
 				continue
 			}else{
-				fmt.Println("Cannot get a result, please decrease your numbers of STLs or enlarge the frame sizes")
+				err_content := err_msg{"Cannot get a result, please decrease your numbers of STLs or enlarge the frame sizes"}
+				fmt.Println(err_content.Error)
+				//err_json, err := json.Marshal(err_content)
+				_, err := json.Marshal(err_content)
+				if err != nil{
+					fmt.Println("error:", err)
+				}
+
+				/*Do the following lines if want to return a json file including the error content*/
+				//ioutil.WriteFile(fmt.Sprintf("%s.json", os.Args[5]), err_json, 0644)
+				//break
+
 				os.Exit(508)
 			}
 
@@ -152,10 +167,12 @@ Add 'break' in the loop to stop program */
 			if err != nil {
 				fmt.Println("error:", err)
 			}
-			ioutil.WriteFile(fmt.Sprintf("%s.json", os.Args[4]), positions_json, 0644)
+			ioutil.WriteFile(fmt.Sprintf("%s.json", os.Args[5]), positions_json, 0644)
 			//os.Stdout.Write(positions_json)
 
-			//model.Mesh().SaveSTL(fmt.Sprintf("pack3d-%.3f.stl", score))  // Add this line if want to generate the packing STL
+			/*Add the following line if want to generate the packing STL*/
+			//model.Mesh().SaveSTL(fmt.Sprintf("pack3d-%s.stl", os.Args[5]))
+
 			// model.TreeMesh().SaveSTL(fmt.Sprintf("out%dtree.stl", int(score*100000)))
 			done()
 			os.Exit(201)

--- a/cmd/pack3d/main.go
+++ b/cmd/pack3d/main.go
@@ -151,7 +151,7 @@ Add 'break' in the loop to stop program */
 				//ioutil.WriteFile(fmt.Sprintf("%s.json", os.Args[5]), err_json, 0644)
 				//break
 
-				os.Exit(508)
+				os.Exit(1)
 			}
 
 		}
@@ -178,7 +178,7 @@ Add 'break' in the loop to stop program */
 
 			// model.TreeMesh().SaveSTL(fmt.Sprintf("out%dtree.stl", int(score*100000)))
 			done()
-			os.Exit(201)
+			os.Exit(0)
 		}
 		model.Reset()
 	}

--- a/pack3d/anneal.go
+++ b/pack3d/anneal.go
@@ -29,6 +29,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 	bestEnergy := state.Energy()
 	previousEnergy := bestEnergy
 	rate := steps / 200
+	var cycleIndex int
 	for step := 0; step < steps; step++ {
 		pct := float64(step) / float64(steps-1)
 		temp := maxTemp * math.Exp(factor*pct)
@@ -37,6 +38,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 			showProgress(step, steps, bestEnergy, time.Since(start).Seconds())
 		}
 		undo, ntime := state.DoMove(singleStlSize, frameSize)
+		cycleIndex = ntime
 		if ntime >= 19990{
 			return bestState, ntime
 		}
@@ -57,7 +59,7 @@ func Anneal(state Annealable, maxTemp, minTemp float64, steps int, callback Anne
 	}
 	showProgress(steps, steps, bestEnergy, time.Since(start).Seconds())
 	fmt.Println()
-	return bestState, 1
+	return bestState, cycleIndex
 }
 
 /* This function shows progress, not necessary*/

--- a/pack3d/bvh.go
+++ b/pack3d/bvh.go
@@ -4,14 +4,14 @@ import "github.com/fogleman/fauxgl"
 
 type Tree []fauxgl.Box
 
-func NewTreeForMesh(mesh *fauxgl.Mesh, depth int) Tree {
+func NewTreeForMesh(mesh *fauxgl.Mesh, depth int, space float64) Tree {
 	mesh = mesh.Copy()
 	mesh.Center()
 	boxes := make([]fauxgl.Box, len(mesh.Triangles))
 	for i, t := range mesh.Triangles {
 		boxes[i] = t.BoundingBox()
 	}
-	root := NewNode(boxes, depth)
+	root := NewNode(boxes, depth, space)
 	tree := make(Tree, 1<<uint(depth+1)-1)
 	root.Flatten(tree, 0)
 	return tree
@@ -69,10 +69,10 @@ type Node struct {
 	Right *Node
 }
 
-func NewNode(boxes []fauxgl.Box, depth int) *Node {
-	box := fauxgl.BoxForBoxes(boxes).Offset(2.5)
+func NewNode(boxes []fauxgl.Box, depth int, space float64) *Node {
+	box := fauxgl.BoxForBoxes(boxes).Offset(space) // change the offset to change the distance between objects
 	node := &Node{box, nil, nil}
-	node.Split(boxes, depth)
+	node.Split(boxes, depth, space)
 	return node
 }
 
@@ -86,7 +86,7 @@ func (a *Node) Flatten(tree Tree, i int) {
 	}
 }
 
-func (node *Node) Split(boxes []fauxgl.Box, depth int) {
+func (node *Node) Split(boxes []fauxgl.Box, depth int, space float64) {
 	if depth == 0 {
 		return
 	}
@@ -130,8 +130,8 @@ func (node *Node) Split(boxes []fauxgl.Box, depth int) {
 		return
 	}
 	l, r := partition(boxes, bestAxis, bestPoint, bestSide)
-	node.Left = NewNode(l, depth-1)
-	node.Right = NewNode(r, depth-1)
+	node.Left = NewNode(l, depth-1, space)
+	node.Right = NewNode(r, depth-1, space)
 }
 
 func partitionBox(box fauxgl.Box, axis Axis, point float64) (left, right bool) {

--- a/pack3d/model.go
+++ b/pack3d/model.go
@@ -78,12 +78,9 @@ func (m *Model) add(mesh *fauxgl.Mesh, trees []Tree) {
 		item.Rotation = rand.Intn(len(Rotations))
 
 		item.Translation = fauxgl.RandomUnitVector().MulScalar(d)
-		//fmt.Println(item.Translation)
-		//fmt.Println("---------------")
 		d *= 1.2
 	}
 	tree := trees[0]
-	//fmt.Println(tree[0].Volume)
 	m.MinVolume = math.Max(m.MinVolume, tree[0].Volume())
 	m.MaxVolume += tree[0].Volume()  // what is tree[0]?
 }
@@ -101,14 +98,11 @@ func (m *Model) Reset() {
 func (m *Model) Pack(iterations int, callback AnnealCallback, singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) (*Model, int) {
 	e := 0.5
 	runannel, ntime:= Anneal(m, 1e0*e, 1e-4*e, iterations, callback, singleStlSize, frameSize)
-	//fmt.Println(1e0*e,  1e-4*e)
-	//fmt.Println("-------------")
 	annealModel := runannel.(*Model)
 	return annealModel, ntime
 }
 
 func (m *Model) Meshes() []*fauxgl.Mesh {
-	//fmt.Println("yes I will")
 	result := make([]*fauxgl.Mesh, len(m.Items))
 	for i, item := range m.Items {
 		mesh := item.Mesh.Copy()
@@ -161,7 +155,6 @@ func (m *Model) TreeMesh() *fauxgl.Mesh {
 func (m *Model) ValidChange(i int) bool {
 	item1 := m.Items[i]
 	tree1 := item1.Trees[item1.Rotation]
-	//fmt.Println(item1.Translation)
 	for j := 0; j < len(m.Items); j++ {  // go through all other items
 		if j == i {
 			continue
@@ -244,7 +237,6 @@ func (m *Model) DoMove(singleStlSize []fauxgl.Vector, frameSize fauxgl.Vector) (
 		}
 
 		if m.ValidChange(i) && m.ValidBound(i, singleStlSize, frameSize) {
-			//fmt.Println(item.Translation)
 			break
 		}
 


### PR DESCRIPTION
# Description:
- Add customized spacing between objects in `pack3d`.
- The command line to use `pack3d` becomes `pack3d {your_frame_size_X,your_frame_size_Y,your_frame_size_Z} spacing your_output_name STL_numbers STL_path STL_numbers STL_path .....`
For example: `pack3d {100,100,100} 5 Pikacu 1 /home/corner.stl 2 /home/Pika.stl`

# Ticket:
- [ch1508](https://app.clubhouse.io/authentise/story/1508/add-minimum-distance-packing)