### PR TITLE
[sc-111928] Security: Update Go to 1.23.8+ to fix CVE-2025-22871

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ It returns a JSON file describing how the input items should be transformed to b
 
 See CONTRIBUTING.md
 
+### Go Version Requirement
+
+This project requires **Go 1.23.8 or later** to compile. This version requirement was updated to address CVE-2025-22871, a security vulnerability in Go's standard library `net/http` package that was fixed in Go 1.23.8. The binary must be compiled with Go 1.23.8+ to ensure the security fix is included.
+
 ### Pack3d command
 
 Pack3d is a multi-step process:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Authentise/pack3d
 
-go 1.22
+go 1.23.8
 
 require (
 	github.com/fogleman/fauxgl v0.0.0-20200818143847-27cddc103802


### PR DESCRIPTION
## Context
Security: Update Go version to 1.23.8+ to fix CVE-2025-22871

Updates go.mod to require Go 1.23.8 or later to address CVE-2025-22871,
a security vulnerability in Go's standard library net/http package that
could enable HTTP request smuggling.

Changes:
- Updated go.mod from Go 1.22 to Go 1.23.8
- Recompiled pack3d binary with Go 1.25.4 (includes 1.23.8+ fixes)
- Added Go version requirement documentation to README

This ensures the binary includes the security fix and prevents the
vulnerability from appearing in Docker image scans.